### PR TITLE
Update plugin.xml and androidAfterPluginAdd.js to fix strings.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -8,25 +8,25 @@
     <js-module src="www/CleverTap.js" name="CleverTap">
         <clobbers target="CleverTap" />
     </js-module>
-    
+
     <engines>
         <engine name="cordova" version=">=3.0.0" />
     </engines>
 
-    <preference name="CLEVERTAP_ACCOUNT_ID" /> 
-    <preference name="CLEVERTAP_TOKEN" /> 
+    <preference name="CLEVERTAP_ACCOUNT_ID" />
+    <preference name="CLEVERTAP_TOKEN" />
 
     <platform name="ios">
 		<config-file>
 			<access origin="*.clevertap.com" />
 		</config-file>
 
-        <config-file target="*-Info.plist" parent="CleverTapAccountID"> 
-            <string>$CLEVERTAP_ACCOUNT_ID</string> 
+        <config-file target="*-Info.plist" parent="CleverTapAccountID">
+            <string>$CLEVERTAP_ACCOUNT_ID</string>
         </config-file>
 
-        <config-file target="*-Info.plist" parent="CleverTapToken"> 
-            <string>$CLEVERTAP_TOKEN</string> 
+        <config-file target="*-Info.plist" parent="CleverTapToken">
+            <string>$CLEVERTAP_TOKEN</string>
         </config-file>
 
 		<config-file parent="aps-environment" target="*/Entitlements-Debug.plist">
@@ -64,13 +64,6 @@
                 <param name="android-package" value="com.clevertap.cordova.CleverTapPlugin"/>
             </feature>
         </config-file>
-
-		<config-file parent="/resources" target="res/values/strings.xml">
-			<string name="google_app_id">@string/google_app_id</string>
-		</config-file>
-		<config-file parent="/resources" target="res/values/strings.xml">
-			<string name="google_api_key">@string/google_api_key</string>
-		</config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.INTERNET" />

--- a/scripts/androidAfterPluginAdd.js
+++ b/scripts/androidAfterPluginAdd.js
@@ -32,11 +32,11 @@ module.exports = function(context) {
     } catch(err) {
         process.stdout.write(err);
     }
-  } 
+  }
   var gsPaths = ["google-services.json", "platforms/android/assets/www/google-services.json"];
 
   for (var i = 0; i < gsPaths.length; i++) {
-    process.stdout.write(gsPaths[i]);  
+    process.stdout.write(gsPaths[i]);
     if (fs.existsSync(gsPaths[i])) {
       try {
         var fileContents = fs.readFileSync(gsPaths[i]).toString();
@@ -50,9 +50,9 @@ module.exports = function(context) {
 
         s = s.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1')
 
-        s = s.replace(new RegExp('<string name="google_app_id">([^<]+?)<\/string>', "i"), '<string name="google_app_id">' + jsonContents.client[0].client_info.mobilesdk_app_id + '</string>')
+        s = s.replace(new RegExp('</resources>', "i"), '<string name="google_app_id">' + jsonContents.client[0].client_info.mobilesdk_app_id + '</string>\n</resources>')
 
-        s = s.replace(new RegExp('<string name="google_api_key">([^<]+?)<\/string>', "i"), '<string name="google_api_key">' + jsonContents.client[0].api_key[0].current_key + '</string>')
+        s = s.replace(new RegExp('</resources>', "i"), '<string name="google_api_key">' + jsonContents.client[0].api_key[0].current_key + '</string>\n</resources>')
 
         fs.writeFileSync("platforms/android/res/values/strings.xml", s);
       } catch (err) {


### PR DESCRIPTION
Keeping 
```xml
<config-file parent="/resources" target="res/values/strings.xml">
    <string name="google_app_id">@string/google_app_id</string>
</config-file>
<config-file parent="/resources" target="res/values/strings.xml">
    <string name="google_api_key">@string/google_api_key</string>
</config-file>
```
in the plugin.xml causes cordova 6.5.0 to add those tags to strings.xml, because the exact match to `@string/google_app_id` and api key do not exist in strings.xml (since they were updated to the actual values in androidAfterPluginAdd.js).

Here's the change I had to do to get it to build; I removed those tags from plugin.xml, and changed the after plugin add regex to append those lines instead of updating them.