### PR TITLE
Android support 28 breaking builds

### DIFF
--- a/Starter/platforms/android/project.properties
+++ b/Starter/platforms/android/project.properties
@@ -14,4 +14,4 @@ target=android-25
 android.library.reference.1=CordovaLib
 cordova.system.library.1=com.google.firebase:firebase-messaging:+
 cordova.system.library.2=com.google.android.gms:play-services-base:+
-cordova.system.library.3=com.android.support:support-v4:+
+cordova.system.library.3=com.android.support:support-v4:27.1.0

--- a/Starter/plugins/com.clevertap.cordova.CleverTapPlugin/plugin.xml
+++ b/Starter/plugins/com.clevertap.cordova.CleverTapPlugin/plugin.xml
@@ -118,7 +118,7 @@
 
         <framework src="com.google.firebase:firebase-messaging:+" />
         <framework src="com.google.android.gms:play-services-base:+" />
-		<framework src="com.android.support:support-v4:+" />
+		<framework src="com.android.support:support-v4:27.1.0" />
 
         <hook type="after_plugin_add" src="scripts/androidAfterPluginAdd.js" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -118,7 +118,7 @@
 
         <framework src="com.google.firebase:firebase-messaging:+" />
         <framework src="com.google.android.gms:play-services-base:+" />
-		<framework src="com.android.support:support-v4:+" />
+		<framework src="com.android.support:support-v4:27.1.0" />
 
         <hook type="after_plugin_add" src="scripts/androidAfterPluginAdd.js" />
 


### PR DESCRIPTION
With the updates to android-support versions this can no longer be maintained using a '+-sign'. 

This change is needed because it will break ionic builds otherwise.