### PR TITLE
Prepare iOS v2.4.0 and update Ionic Cordova example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
-Change Log
-==========
+## Change Log
+
+### Version 2.4.0 (September 21, 2021)
+* Adds public methods for suspending, discarding & resuming InApp Notifications
+* Adds public methods to increment/decrement values set via User properties
+* Deprecates `profileGetCleverTapID()` and `profileGetCleverTapAttributionIdentifier()` methods
+* Adds a new public method `getCleverTapID()` as an alternative to above deprecated methods
+* Supports [CleverTap iOS SDK v3.10.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/3.10.0)
+* Supports [CleverTap Android SDK v4.2.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/core-v4.2.0)
 
 Version 2.3.5 *(9th June 2021)*
 -------------------------------------------

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ## ✅ Supported Versions
 
-- [CleverTap Android SDK version 4.1.1](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/core-v4.1.1)
-- [CleverTap iOS SDK version 3.9.4](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/3.9.4)
+- [CleverTap Android SDK version 4.2.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/core-v4.2.0)
+- [CleverTap iOS SDK version 3.10.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/3.10.0)
 
 ## 🚀 Installation and Quick Start
 
@@ -66,7 +66,7 @@ npm install @ionic-native/clevertap --save
 
       ...
       clevertap.setDebugLevel(2);
-      clevertap.profileGetCleverTapID((id) => {console.log(id)});
+      clevertap.getCleverTapID()((id) => {console.log(id)});
       ...
     });
   }

--- a/Samples/IonicCordova/IonicAngularProject/src/app/home/home.page.html
+++ b/Samples/IonicCordova/IonicAngularProject/src/app/home/home.page.html
@@ -45,10 +45,8 @@
         profileGooglePlusUser</ion-item>
     <ion-item (click)="profileGetProperty()">
         profileGetProperty</ion-item>
-    <ion-item (click)="profileGetCleverTapAttributionIdentifier()">
-        profileGetCleverTapAttributionIdentifier</ion-item>
-    <ion-item (click)="profileGetCleverTapID()">
-        profileGetCleverTapID</ion-item>
+    <ion-item (click)="getCleverTapID()">
+        getCleverTapID</ion-item>
     <ion-item (click)="profileRemoveValueForKey()">
         profileRemoveValueForKey</ion-item>
     <ion-item (click)="profileSetMultiValues()">
@@ -61,6 +59,10 @@
         profileRemoveMultiValue</ion-item>
     <ion-item (click)="profileRemoveMultiValues()">
         profileRemoveMultiValues</ion-item>
+    <ion-item (click)="profileIncrementValueBy()">
+        profileIncrementValue</ion-item>
+    <ion-item (click)="profileDecrementValueBy()">
+        profileDecrementValue</ion-item>
     
     <ion-list-header>
       <ion-label>Personalization</ion-label>
@@ -148,6 +150,16 @@
         pushInboxNotificationViewedEventForId</ion-item>
     <ion-item (click)="pushInboxNotificationClickedEventForId()">
         pushInboxNotificationClickedEventForId</ion-item>
+
+    <ion-list-header>
+     <ion-label>In-App notification controls</ion-label>
+    </ion-list-header>
+    <ion-item (click)="suspendInAppNotifications()">
+        suspendInAppNotifications</ion-item>
+    <ion-item (click)="discardInAppNotifications()">
+        discardInAppNotifications</ion-item>
+    <ion-item (click)="resumeInAppNotifications()">
+        resumeInAppNotifications</ion-item>
     
     <ion-list-header>
       <ion-label>Native Display</ion-label>

--- a/Samples/IonicCordova/IonicAngularProject/src/app/home/home.page.ts
+++ b/Samples/IonicCordova/IonicAngularProject/src/app/home/home.page.ts
@@ -157,17 +157,10 @@ export class HomePage {
         });
     }
 
-    profileGetCleverTapAttributionIdentifier() {
-        console.log('profileGetCleverTapAttributionIdentifier');
-        this.clevertap.profileGetCleverTapAttributionIdentifier().then(r => {
-            this.presentToast('profileGetCleverTapAttributionIdentifier' + r)
-        });
-    }
-
-    profileGetCleverTapID() {
-        console.log('profileGetCleverTapID');
-        this.clevertap.profileGetCleverTapID().then(r => {
-                this.presentToast('profileGetCleverTapID' + r);
+    getCleverTapID() {
+        console.log('getCleverTapID');
+        this.clevertap.getCleverTapID().then(r => {
+            this.presentToast('getCleverTapID' + r);
         });
     }
 
@@ -205,6 +198,18 @@ export class HomePage {
         console.log('profileRemoveMultiValues');
         this.clevertap.profileRemoveMultiValues('colors', ['purple', 'pink']);
         this.presentToast('profileRemoveMultiValues: removing value \'[purple, pink]\' for key \'colors\'')
+    }
+
+    profileIncrementValueBy() {
+        console.log('profileIncrementValueBy');
+        this.clevertap.profileIncrementValueBy('score', '15');
+        this.presentToast('profileIncrementValueBy: increment value \'score\' by \'15\'')
+    }
+
+    profileDecrementValueBy() {
+        console.log('profileDecrementValueBy');
+        this.clevertap.profileDecrementValueBy('score', '10');
+        this.presentToast('profileDecrementValueBy: decrement value \'score\' by \'10\'')
     }
 
     enablePersonalization() {
@@ -428,6 +433,21 @@ export class HomePage {
     pushInboxNotificationClickedEventForId() {
         console.log('pushInboxNotificationClickedEventForId');
         this.clevertap.pushInboxNotificationClickedEventForId('Insert message id');
+    }
+
+    suspendInAppNotifications() {
+        console.log('suspendInAppNotifications');
+        this.clevertap.suspendInAppNotifications();
+    }
+
+    discardInAppNotifications() {
+        console.log('discardInAppNotifications');
+        this.clevertap.discardInAppNotifications();
+    }
+
+    resumeInAppNotifications() {
+        console.log('resumeInAppNotifications');
+        this.clevertap.resumeInAppNotifications();
     }
 
     getAllDisplayUnits() {

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -121,6 +121,18 @@ this.clevertap.profileRemoveMultiValue('colors', 'green');
 this.clevertap.profileAddMultiValue('colors', 'green');
 ```
 
+#### Increment Value For Key
+
+```javascript 
+this.clevertap.profileIncrementValueBy('score', 15);
+```
+
+#### Decrement Value For Key
+
+```javascript 
+this.clevertap.profileDecrementValueBy('score', 10);
+```
+
 #### Create a User profile when user logs in (On User Login)
 
 ```javascript 
@@ -275,6 +287,26 @@ this.clevertap.deleteNotificationChannelGroup('groupID_5678');
 this.clevertap.setPushToken('<Token Value>');
 ```
  
+## InApp Notification Controls
+
+#### Suspend InApp Notifications
+
+```javascript 
+this.clevertap.suspendInAppNotifications();
+```
+
+#### Discard InApp Notifications
+
+```javascript 
+this.clevertap.discardInAppNotifications();
+```
+
+#### Resume InApp Notifications
+
+```javascript 
+this.clevertap.resumeInAppNotifications();
+```
+
 ## Native Display
 
 #### Get Display Unit for Id
@@ -402,13 +434,11 @@ this.clevertap.profileGetProperty('Name').then(r => {
 });	
 ```
 
-## Attributions
-
-#### Get CleverTap Attribution Identifier
+#### Get CleverTap Identifier
 
 ```javascript 
-this.clevertap.profileGetCleverTapAttributionIdentifier('Name').then(r => {
-   console.log('profileGetCleverTapAttributionIdentifier: ' + r);
+this.clevertap.getCleverTapID().then(r => {
+   console.log('getCleverTapID: ' + r);
 });	
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-cordova",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-cordova",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "CleverTap Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "clevertap-cordova",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-cordova",
-  "version": "2.3.6",
+  "version": "2.4.0",
   "description": "CleverTap Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "clevertap-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.3.6">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.4.0">
     <name>CleverTap</name>
     <description>CleverTap Plugin for Cordova/PhoneGap</description>
     <license>Commercial</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.3.5">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.3.6">
     <name>CleverTap</name>
     <description>CleverTap Plugin for Cordova/PhoneGap</description>
     <license>Commercial</license>
@@ -46,7 +46,7 @@
             </feature>
         </config-file>
 
-        <framework src="CleverTap-iOS-SDK" type="podspec" spec="3.9.4" />
+        <framework src="CleverTap-iOS-SDK" type="podspec" spec="3.10.0" />
         <header-file src="src/ios/AppDelegate+CleverTapPlugin.h" />
         <source-file src="src/ios/AppDelegate+CleverTapPlugin.m" />
         <header-file src="src/ios/CleverTapPlugin.h" />

--- a/src/ios/CleverTapPlugin.h
+++ b/src/ios/CleverTapPlugin.h
@@ -95,6 +95,24 @@ static NSString * const CTHandleOpenURLNotification = @"CTHandleOpenURLNotificat
 - (void)pushNotificationTappedWithCustomExtras:(NSDictionary *)customExtras;
 
 
+#pragma mark - InApp Notification Controls
+
+/**
+ Suspends and saves inApp notifications until 'resumeInAppNotifications' is called for current session.
+ Automatically resumes InApp notifications display on CleverTap shared instance creation. Pending inApp notifications are displayed only for current session.
+ */
+- (void)suspendInAppNotifications;
+
+/**
+ Discards inApp notifications until 'resumeInAppNotifications' is called for current session.
+ Automatically resumes InApp notifications display on CleverTap shared instance creation. Pending inApp notifications are not displayed. */
+- (void)discardInAppNotifications;
+
+/**
+ Resumes displaying inApps notifications and shows pending inApp notifications if any.
+ */
+- (void)resumeInAppNotifications;
+
 #pragma mark - CleverTapInAppNotificationDelegate
 
 /**
@@ -210,11 +228,17 @@ static NSString * const CTHandleOpenURLNotification = @"CTHandleOpenURLNotificat
 
 /** Get the CleverTap ID of the User Profile. The CleverTap ID is the unique identifier assigned to the User Profile by CleverTap.
  */
+//  @Deprecated("This method is deprecated since v2.3.5. Use getCleverTapID() instead")
 - (void)profileGetCleverTapID:(CDVInvokedUrlCommand *)command;
 
 /** Returns a unique CleverTap identifier suitable for use with install attribution providers.
  */
+// @Deprecated("This method is deprecated since v2.3.5. Use getCleverTapID() instead")
 - (void)profileGetCleverTapAttributionIdentifier:(CDVInvokedUrlCommand *)command;
+
+/** Returns a unique CleverTap identifier suitable for use with install attribution providers.
+ */
+- (void)getCleverTapID:(CDVInvokedUrlCommand *)command;
 
 /** Remove the property specified by key from the user profile.
  */
@@ -257,6 +281,14 @@ static NSString * const CTHandleOpenURLNotification = @"CTHandleOpenURLNotificat
  If the multi-value property is empty after the remove operation, the key will be removed.
  */
 - (void)profileRemoveMultiValues:(CDVInvokedUrlCommand *)command;
+
+/** Method for incrementing a value for a single-value profile property (if it exists).
+*/
+- (void)profileIncrementValueBy:(CDVInvokedUrlCommand *)command;
+
+/** Method for decrementing a value for a single-value profile property (if it exists).
+*/
+- (void)profileDecrementValueBy:(CDVInvokedUrlCommand *)command;
 
 #pragma mark - Session API
 

--- a/src/ios/CleverTapPlugin.h
+++ b/src/ios/CleverTapPlugin.h
@@ -228,13 +228,11 @@ static NSString * const CTHandleOpenURLNotification = @"CTHandleOpenURLNotificat
 
 /** Get the CleverTap ID of the User Profile. The CleverTap ID is the unique identifier assigned to the User Profile by CleverTap.
  */
-//  @Deprecated("This method is deprecated since v2.3.5. Use getCleverTapID() instead")
-- (void)profileGetCleverTapID:(CDVInvokedUrlCommand *)command;
+- (void)profileGetCleverTapID:(CDVInvokedUrlCommand *)command __attribute__((deprecated("This method is deprecated in v2.3.5. Use getCleverTapID() instead")));
 
 /** Returns a unique CleverTap identifier suitable for use with install attribution providers.
  */
-// @Deprecated("This method is deprecated since v2.3.5. Use getCleverTapID() instead")
-- (void)profileGetCleverTapAttributionIdentifier:(CDVInvokedUrlCommand *)command;
+- (void)profileGetCleverTapAttributionIdentifier:(CDVInvokedUrlCommand *)command __attribute__((deprecated("This method is deprecated in v2.3.5. Use getCleverTapID() instead")));
 
 /** Returns a unique CleverTap identifier suitable for use with install attribution providers.
  */

--- a/src/ios/CleverTapPlugin.m
+++ b/src/ios/CleverTapPlugin.m
@@ -866,7 +866,7 @@ static NSDateFormatter *dateFormatter;
     
     [self.commandDelegate runInBackground:^{
         NSString *key = [command argumentAtIndex:0];
-        NSString *value = [command argumentAtIndex:1];
+        NSNumber *value = [command argumentAtIndex:1];
         if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSNumber class]]) {
             [clevertap profileIncrementValueBy: value forKey:key];
         }
@@ -877,7 +877,7 @@ static NSDateFormatter *dateFormatter;
     
     [self.commandDelegate runInBackground:^{
         NSString *key = [command argumentAtIndex:0];
-        NSString *value = [command argumentAtIndex:1];
+        NSNumber *value = [command argumentAtIndex:1];
         if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSNumber class]]) {
             [clevertap profileDecrementValueBy: value forKey:key];
         }

--- a/src/ios/CleverTapPlugin.m
+++ b/src/ios/CleverTapPlugin.m
@@ -867,7 +867,7 @@ static NSDateFormatter *dateFormatter;
     [self.commandDelegate runInBackground:^{
         NSString *key = [command argumentAtIndex:0];
         NSString *value = [command argumentAtIndex:1];
-        if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSString class]]) {
+        if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSNumber class]]) {
             [clevertap profileIncrementValueBy: value forKey:key];
         }
     }];
@@ -878,7 +878,7 @@ static NSDateFormatter *dateFormatter;
     [self.commandDelegate runInBackground:^{
         NSString *key = [command argumentAtIndex:0];
         NSString *value = [command argumentAtIndex:1];
-        if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSString class]]) {
+        if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSNumber class]]) {
             [clevertap profileDecrementValueBy: value forKey:key];
         }
     }];

--- a/src/ios/CleverTapPlugin.m
+++ b/src/ios/CleverTapPlugin.m
@@ -24,6 +24,7 @@
 #import "CleverTap+ProductConfig.h"
 #import "CleverTapPushNotificationDelegate.h"
 #import "CleverTapInAppNotificationDelegate.h"
+#import "CleverTap+InAppNotifications.h"
 
 #import <CoreLocation/CoreLocation.h>
 
@@ -56,7 +57,7 @@ static NSDateFormatter *dateFormatter;
 + (void)onDidFinishLaunchingNotification:(NSNotification *)notification {
     
     clevertap = [CleverTap sharedInstance];
-    
+
     NSDictionary *launchOptions = notification.userInfo;
     if (!launchOptions) return;
     
@@ -448,6 +449,20 @@ static NSDateFormatter *dateFormatter;
     NSLog(@"deleteNotificationChannelGroup is no-op in iOS");
 }
 
+#pragma mark - InApp Notification Controls
+
+- (void)suspendInAppNotifications {
+    [clevertap suspendInAppNotifications];
+}
+
+- (void)discardInAppNotifications {
+    [clevertap discardInAppNotifications];
+}
+
+- (void)resumeInAppNotifications {
+    [clevertap resumeInAppNotifications];
+}
+
 
 #pragma mark - Push Notification Delegate
 
@@ -776,6 +791,10 @@ static NSDateFormatter *dateFormatter;
     }];
 }
 
+- (void)getCleverTapID:(CDVInvokedUrlCommand *)command {
+    [self profileGetCleverTapID: command];
+}
+
 - (void)profileRemoveValueForKey:(CDVInvokedUrlCommand *)command {
     
     [self.commandDelegate runInBackground:^{
@@ -843,6 +862,27 @@ static NSDateFormatter *dateFormatter;
     }];
 }
 
+- (void)profileIncrementValueBy:(CDVInvokedUrlCommand *)command {
+    
+    [self.commandDelegate runInBackground:^{
+        NSString *key = [command argumentAtIndex:0];
+        NSString *value = [command argumentAtIndex:1];
+        if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSString class]]) {
+            [clevertap profileIncrementValueBy: value forKey:key];
+        }
+    }];
+}
+
+- (void)profileDecrementValueBy:(CDVInvokedUrlCommand *)command {
+    
+    [self.commandDelegate runInBackground:^{
+        NSString *key = [command argumentAtIndex:0];
+        NSString *value = [command argumentAtIndex:1];
+        if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSString class]]) {
+            [clevertap profileDecrementValueBy: value forKey:key];
+        }
+    }];
+}
 
 #pragma mark Session API
 

--- a/src/ios/CleverTapPlugin.m
+++ b/src/ios/CleverTapPlugin.m
@@ -792,7 +792,22 @@ static NSDateFormatter *dateFormatter;
 }
 
 - (void)getCleverTapID:(CDVInvokedUrlCommand *)command {
-    [self profileGetCleverTapID: command];
+    
+    [self.commandDelegate runInBackground:^{
+        CDVPluginResult *pluginResult;
+        
+        NSString *cleverTapID = [clevertap profileGetCleverTapID];
+        
+        if(cleverTapID == nil) {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:NO];
+        }
+        
+        else  {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:cleverTapID];
+        }
+        
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
 }
 
 - (void)profileRemoveValueForKey:(CDVInvokedUrlCommand *)command {

--- a/src/ios/CleverTapPlugin.m
+++ b/src/ios/CleverTapPlugin.m
@@ -883,7 +883,7 @@ static NSDateFormatter *dateFormatter;
         NSString *key = [command argumentAtIndex:0];
         NSNumber *value = [command argumentAtIndex:1];
         if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSNumber class]]) {
-            [clevertap profileIncrementValueBy: value forKey:key];
+            [clevertap profileIncrementValueBy:value forKey:key];
         }
     }];
 }
@@ -894,7 +894,7 @@ static NSDateFormatter *dateFormatter;
         NSString *key = [command argumentAtIndex:0];
         NSNumber *value = [command argumentAtIndex:1];
         if (key != nil && [key isKindOfClass:[NSString class]] && value != nil && [value isKindOfClass:[NSNumber class]]) {
-            [clevertap profileDecrementValueBy: value forKey:key];
+            [clevertap profileDecrementValueBy:value forKey:key];
         }
     }];
 }

--- a/www/CleverTap.js
+++ b/www/CleverTap.js
@@ -269,18 +269,31 @@ CleverTap.prototype.profileGetProperty = function (propertyName, successCallback
     cordova.exec(successCallback, null, "CleverTapPlugin", "profileGetProperty", [propertyName]);
 }
 
-// Get a unique CleverTap identifier suitable for use with install attribution providers.
-// successCallback = callback function for result
-// success returns the unique CleverTap attribution identifier.
+/**
+* @deprecated This method is deprecated since v2.3.5. Use getCleverTapID() instead.               
+* Get a unique CleverTap identifier suitable for use with install attribution providers
+* successCallback = callback function for result
+* success returns the unique CleverTap attribution identifier
+*/
 CleverTap.prototype.profileGetCleverTapAttributionIdentifier = function (successCallback) {
     cordova.exec(successCallback, null, "CleverTapPlugin", "profileGetCleverTapAttributionIdentifier", []);
 }
-               
+
+/**
+* @deprecated This method is deprecated since v2.3.5. Use getCleverTapID() instead.               
+* Get User Profile CleverTapID
+* successCallback = callback function for result
+* success calls back with CleverTapID or false
+*/
+CleverTap.prototype.profileGetCleverTapID = function (successCallback) {
+    cordova.exec(successCallback, null, "CleverTapPlugin", "profileGetCleverTapID", []);
+}
+
 // Get User Profile CleverTapID
 // successCallback = callback function for result
 // success calls back with CleverTapID or false
-CleverTap.prototype.profileGetCleverTapID = function (successCallback) {
-    cordova.exec(successCallback, null, "CleverTapPlugin", "profileGetCleverTapID", []);
+CleverTap.prototype.getCleverTapID = function (successCallback) {
+    cordova.exec(successCallback, null, "CleverTapPlugin", "getCleverTapID", []);
 }
 
 // Remove the property specified by key from the user profile
@@ -322,6 +335,19 @@ CleverTap.prototype.profileRemoveMultiValue = function (key, value) {
 // values = array of strings
 CleverTap.prototype.profileRemoveMultiValues = function (key, values) {
     cordova.exec(null, null, "CleverTapPlugin", "profileRemoveMultiValues", [key, values]);
+}
+// Method for incrementing a value for a single-value profile property (if it exists).
+// key = string
+// values = array of strings
+CleverTap.prototype.profileIncrementValueBy = function (key, value) {
+    cordova.exec(null, null, "CleverTapPlugin", "profileIncrementValueBy", [key, value]);
+}
+
+// Method for decrementing a value for a single-value profile property (if it exists).
+// key = string
+// values = array of strings
+CleverTap.prototype.profileDecrementValueBy = function (key, value) {
+    cordova.exec(null, null, "CleverTapPlugin", "profileDecrementValueBy", [key, value]);
 }
                
 /*******************
@@ -433,6 +459,31 @@ CleverTap.prototype.pushInboxNotificationViewedEventForId = function (messageId)
 
 CleverTap.prototype.pushInboxNotificationClickedEventForId = function (messageId) {
      cordova.exec(null, null, "CleverTapPlugin", "pushInboxNotificationClickedEventForId", [messageId]);
+}
+
+/*******************
+ * In-App Controls
+ ******************/
+/**
+ Suspends and saves inApp notifications until 'resumeInAppNotifications' is called for current session.
+ Automatically resumes InApp notifications display on CleverTap shared instance creation. Pending inApp notifications are displayed only for current session.
+ */
+CleverTap.prototype.suspendInAppNotifications = function () {
+    cordova.exec(null, null, "CleverTapPlugin", "suspendInAppNotifications", []);
+}
+
+/**
+ Discards inApp notifications until 'resumeInAppNotifications' is called for current session.
+ Automatically resumes InApp notifications display on CleverTap shared instance creation. Pending inApp notifications are not displayed. */
+CleverTap.prototype.discardInAppNotifications = function () {
+    cordova.exec(null, null, "CleverTapPlugin", "discardInAppNotifications", []);
+}
+
+/**
+ Resumes displaying inApps notifications and shows pending inApp notifications if any.
+ */
+CleverTap.prototype.resumeInAppNotifications = function () {
+    cordova.exec(null, null, "CleverTapPlugin", "resumeInAppNotifications", []);
 }
 
 /****************************

--- a/www/CleverTap.js
+++ b/www/CleverTap.js
@@ -338,14 +338,14 @@ CleverTap.prototype.profileRemoveMultiValues = function (key, values) {
 }
 // Method for incrementing a value for a single-value profile property (if it exists).
 // key = string
-// values = array of strings
+// values = number
 CleverTap.prototype.profileIncrementValueBy = function (key, value) {
     cordova.exec(null, null, "CleverTapPlugin", "profileIncrementValueBy", [key, value]);
 }
 
 // Method for decrementing a value for a single-value profile property (if it exists).
 // key = string
-// values = array of strings
+// values = number
 CleverTap.prototype.profileDecrementValueBy = function (key, value) {
     cordova.exec(null, null, "CleverTapPlugin", "profileDecrementValueBy", [key, value]);
 }

--- a/www/CleverTap.js
+++ b/www/CleverTap.js
@@ -270,7 +270,7 @@ CleverTap.prototype.profileGetProperty = function (propertyName, successCallback
 }
 
 /**
-* @deprecated This method is deprecated since v2.3.5. Use getCleverTapID() instead.               
+* @deprecated This method is deprecated in v2.3.5. Use getCleverTapID() instead.
 * Get a unique CleverTap identifier suitable for use with install attribution providers
 * successCallback = callback function for result
 * success returns the unique CleverTap attribution identifier
@@ -280,7 +280,7 @@ CleverTap.prototype.profileGetCleverTapAttributionIdentifier = function (success
 }
 
 /**
-* @deprecated This method is deprecated since v2.3.5. Use getCleverTapID() instead.               
+* @deprecated This method is deprecated in v2.3.5. Use getCleverTapID() instead.
 * Get User Profile CleverTapID
 * successCallback = callback function for result
 * success calls back with CleverTapID or false
@@ -338,14 +338,14 @@ CleverTap.prototype.profileRemoveMultiValues = function (key, values) {
 }
 // Method for incrementing a value for a single-value profile property (if it exists).
 // key = string
-// values = number
+// value = number
 CleverTap.prototype.profileIncrementValueBy = function (key, value) {
     cordova.exec(null, null, "CleverTapPlugin", "profileIncrementValueBy", [key, value]);
 }
 
 // Method for decrementing a value for a single-value profile property (if it exists).
 // key = string
-// values = number
+// value = number
 CleverTap.prototype.profileDecrementValueBy = function (key, value) {
     cordova.exec(null, null, "CleverTapPlugin", "profileDecrementValueBy", [key, value]);
 }


### PR DESCRIPTION
Adds InApp Notifications controls
Adds public methods to increment/decrement values
Deprecates `profileGetCleverTapID()` and `profileGetCleverTapAttributionIdentifier()` methods
Adds a new public method `getCleverTapID()` as an alternative to above deprecated methods
Supports CleverTap iOS SDK v3.10.0
