### PR TITLE
SDK-2903: Fixed compilation errors in Xcode 14.3+ in iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Change Log
 ==========
-Version 2.6.2 *(April 17, 2023)*
+Version 2.6.2 *(April 18, 2023)*
 -------------------------------------------
 - Fixed compilation errors in xcode 14.3+ in iOS.
 - Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Change Log
 ==========
+Version 2.6.2 *(April 17, 2023)*
+-------------------------------------------
+- Fixed compilation errors in xcode 14.3+ in iOS.
+- Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.2).
+
 Version 2.6.1 *(January 25, 2023)*
 -------------------------------------------
 - Fixes a compilation error with iOS app inbox callback method `messageDidSelect`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 ## ✅ Supported Versions
 
 - [CleverTap Android SDK version 4.6.6](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev4.6.6)
-- [CleverTap iOS SDK version 4.2.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.0)
+- [CleverTap iOS SDK version 4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.2)
 
 ## 🚀 Installation and Quick Start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-cordova",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "CleverTap Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "clevertap-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.6.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.6.2">
     <name>CleverTap</name>
     <description>CleverTap Plugin for Cordova/PhoneGap</description>
     <license>Commercial</license>
@@ -40,7 +40,7 @@
             </feature>
         </config-file>
 
-        <framework src="CleverTap-iOS-SDK" type="podspec" spec="4.2.0" />
+        <framework src="CleverTap-iOS-SDK" type="podspec" spec="4.2.2" />
         <header-file src="src/ios/AppDelegate+CleverTapPlugin.h" />
         <source-file src="src/ios/AppDelegate+CleverTapPlugin.m" />
         <header-file src="src/ios/CleverTapPlugin.h" />


### PR DESCRIPTION
- Fixed compilation errors in Xcode 14.3+ in iOS.
- Supports CleverTap iOS SDK v4.2.2