### PR TITLE
Release v2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Change Log
 ==========
+Version 2.6.2 *(April 18, 2023)*
+-------------------------------------------
+- Fixed compilation errors in xcode 14.3+ in iOS.
+- Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.2).
+
 Version 2.6.1 *(January 25, 2023)*
 -------------------------------------------
 - Fixes a compilation error with iOS app inbox callback method `messageDidSelect`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 ## ✅ Supported Versions
 
 - [CleverTap Android SDK version 4.6.6](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev4.6.6)
-- [CleverTap iOS SDK version 4.2.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.0)
+- [CleverTap iOS SDK version 4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.2)
 
 ## 🚀 Installation and Quick Start
 

--- a/Samples/Cordova/ExampleProject/platforms/ios/ExampleProject/ExampleProject-Info.plist
+++ b/Samples/Cordova/ExampleProject/platforms/ios/ExampleProject/ExampleProject-Info.plist
@@ -25,9 +25,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMainNibFile</key>
-	<string/>
+	<string></string>
 	<key>NSMainNibFile~ipad</key>
-	<string/>
+	<string></string>
 	<key>UILaunchStoryboardName</key>
 	<string>CDVLaunchScreen</string>
 	<key>UIRequiresFullScreen</key>
@@ -54,7 +54,5 @@
 	<string>TEST-R78-ZZK-955Z</string>
 	<key>CleverTapToken</key>
 	<string>TEST-311-ba2</string>
-	<key>CleverTapRegion</key>
-	<string/>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-cordova",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "CleverTap Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "clevertap-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.6.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.6.2">
     <name>CleverTap</name>
     <description>CleverTap Plugin for Cordova/PhoneGap</description>
     <license>Commercial</license>
@@ -40,7 +40,7 @@
             </feature>
         </config-file>
 
-        <framework src="CleverTap-iOS-SDK" type="podspec" spec="4.2.0" />
+        <framework src="CleverTap-iOS-SDK" type="podspec" spec="4.2.2" />
         <header-file src="src/ios/AppDelegate+CleverTapPlugin.h" />
         <source-file src="src/ios/AppDelegate+CleverTapPlugin.m" />
         <header-file src="src/ios/CleverTapPlugin.h" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.6.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.6.1">
     <name>CleverTap</name>
     <description>CleverTap Plugin for Cordova/PhoneGap</description>
     <license>Commercial</license>


### PR DESCRIPTION
- Fixed compilation errors in xcode 14.3+ in iOS.
- Supports [CleverTap iOS SDK v4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.2).