### PR TITLE
Android changes for v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 Change Log
 ==========
+Version 2.7.0 *(August 2, 2023)*
+-------------------------------------------
+#### New Features
+
+* Supports [CleverTap Android SDK v5.1.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev5.1.0_ptv1.1.0).
+* Supports [cordova android 12.0.0](https://cordova.apache.org/announcements/2023/05/22/cordova-android-12.0.0.html)
+* Adds below new public APIs for supporting [Android 13 notification runtime permission](https://developer.android.com/develop/ui/views/notifications/notification-permission)
+  * `isPushPermissionGranted(successCallback)` [Usage can be found here](docs/pushprimer.md#get-the-push-notification-permission-status)
+  * `promptPushPrimer(JSONObject)` [Usage can be found here](docs/pushprimer.md#push-primer-using-half-interstitial-local-in-app)
+  * `promptForPushPermission(boolean)` [Usage can be found here](docs/pushprimer.md#prompt-the-notification-permission-dialog-without-push-primer)
+  * New callback `onCleverTapPushPermissionResponseReceived` available which returns after user Allows/Denies notification permission [Usage can be found here](docs/pushprimer.md#available-callbacks-for-push-primer)
+  * New callback `onCleverTapInAppNotificationShow(JSONObject)`
+* Adds support for Remote Config Variables. Please refer to the [Variables.md](docs/Variables.md) file to
+  read more on how to integrate this to your app.
+* Adds new API, `markReadInboxMessagesForIds(messageIDs)` to mark read an array of
+  Inbox Messages.
+* `deleteInboxMessagesForIds(messageIDs)` is now supported in Android as well.
+* Adds new API, `dismissInbox()` to dismiss the App Inbox.
+
+#### API Changes
+
+* **Deprecated:** The following methods and callbacks related to Product Config and Feature Flags have
+  been marked as deprecated in this release, instead use new remote config variables feature. These
+  methods and callbacks will be removed in the future versions with prior notice.
+    * Product config
+        - `setDefaultsMap()`
+        - `fetch()`
+        - `fetchWithMinimumFetchIntervalInSeconds()`
+        - `activate()`
+        - `fetchAndActivate()`
+        - `setMinimumFetchIntervalInSeconds()`
+        - `getLastFetchTimeStampInMillis()`
+        - `getString()`
+        - `getBoolean()`
+        - `getLong()`
+        - `getDouble()`
+        - `reset()`
+        - callback `onCleverTapProductConfigDidInitialize`
+        - callback `onCleverTapProductConfigDidFetch`
+        - callback `onCleverTapProductConfigDidActivate`
+ 
+    * Feature flags
+        - `getFeatureFlag()`
+        - callback `onCleverTapFeatureFlagsDidUpdate`
+
+#### Breaking API Changes
+
+* **Return value change of `onCleverTapInboxItemClick` callback**: callback returns `JSONObject` with below entries
+    - `data` corresponds to the payload of clicked inbox item
+    - The `contentPageIndex` corresponds to the page index of the content, which ranges from 0 to the total number of pages for carousel templates. For non-carousel templates, the value is always 0, as they only have one page of content.
+    - The `buttonIndex` represents the index of the App Inbox button clicked (0, 1, or 2). A value of -1 indicates the App Inbox item is clicked.
+* **Behavioral change of `onCleverTapInboxItemClick` callback**:
+  - Previously, the callback was raised when the App Inbox Item is clicked.
+  - Now, it is also raised when the App Inbox button and Item is clicked.
+
+
 Version 2.6.2 *(April 18, 2023)*
 -------------------------------------------
 - Fixed compilation errors in xcode 14.3+ in iOS.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ## ✅ Supported Versions
 
-- [CleverTap Android SDK version 4.6.6](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev4.6.6)
+- [CleverTap Android SDK version 5.1.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev5.1.0_ptv1.1.0)
 - [CleverTap iOS SDK version 4.2.2](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.2.2)
 
 ## 🚀 Installation and Quick Start

--- a/Samples/Cordova/ExampleProject/www/js/index.js
+++ b/Samples/Cordova/ExampleProject/www/js/index.js
@@ -16,7 +16,69 @@ function log(param){
 }
 
 function setupButtons() {
+    let variables = {
+        'cordova_var_string': 'cordova_var_string_value',
+        'cordova_var_map': {
+          cordova_var_map_string: 'cordova_var_map_value',
+          cordova_var_map_float: 10.11,
+          cordova_var_map_nested:{
+            cordova_var_map_nested_float:3.14
+          }
+        },
+        'cordova_var_int': 6,
+        'cordova_var_float': 6.9,
+        'cordova_var_boolean': true
+      };
+      
+
     let eventsMap = [
+        ["title","Android 13 Push Primer"],
+        ["promptPushPrimer",()=> CleverTap.promptPushPrimer({
+            inAppType: 'alert',
+            titleText: 'Get Notified',
+            messageText:
+              'Please enable notifications on your device to use Push Notifications.',
+            followDeviceOrientation: true,
+            positiveBtnText: 'Allow',
+            negativeBtnText: 'Cancel',
+            backgroundColor: '#FFFFFF',
+            btnBorderColor: '#FF0000',
+            titleTextColor: '#0000FF',
+            messageTextColor: '#000000',
+            btnTextColor: '#FFFFFF',
+            btnBackgroundColor: '#0000FF',
+            btnBorderRadius: '5',
+            imageUrl:"https://icons.iconarchive.com/icons/treetog/junior/64/camera-icon.png",
+            fallbackToSettings: true
+          })
+      ],
+      ["promptForPushPermission",()=> CleverTap.promptForPushPermission(true)],
+      ["isPushPermissionGranted",()=> CleverTap.isPushPermissionGranted(val => log("isPushPermissionGranted value is " + val))],
+
+      ["title","Product Experiences"],
+      ["defineVariables", () => CleverTap.defineVariables(variables)],
+      ["syncVariables", () => CleverTap.syncVariables()],
+      ["syncVariablesinProd", () => CleverTap.syncVariablesinProd()],
+      ["fetchVariables", () => CleverTap.fetchVariables(success => log("fetchVariables success = " + success))],
+      ["getVariable", () => { 
+        let key = prompt("Please enter key", "cordova_var_string");
+         CleverTap.getVariable(key,val => log(key+" value is "+JSON.stringify(val)));
+       }
+      ],
+      ["getVariables", () => { 
+         CleverTap.getVariables(val => log("getVariables value is "+val.cordova_var_map.cordova_var_map_nested.cordova_var_map_nested_float));
+       }
+      ],
+      ["onVariablesChanged", () => { 
+        CleverTap.onVariablesChanged(val => log("onVariablesChanged value is "+JSON.stringify(val)));
+      }
+     ],
+     ["onValueChanged", () => { 
+        let key = prompt("Please enter key", "cordova_var_string");
+        CleverTap.onValueChanged(key,val => log("onValueChanged value is "+JSON.stringify(val)));
+      }
+     ],
+
         ["title","Events"],
         ["record Event With Name", () => CleverTap.recordEventWithName("foo")],
         ["record Event With NameAndProps", () => CleverTap.recordEventWithNameAndProps("boo", {"bar": "zoo"})],
@@ -97,6 +159,8 @@ function setupButtons() {
 
         ["title","Device Identifiers"],
         ["get CleverTap ID", () => CleverTap.getCleverTapID(val => log("getCleverTapID is " + val))],
+
+        
 
         ["title","special functions for cordova sdk"],
         ["Push tokens manually", () => {
@@ -283,8 +347,10 @@ function initListeners() {
             CleverTap.deleteInboxMessageForId("messageId")
             CleverTap.deleteInboxMessagesForIds(["id1", "id2"])
             CleverTap.markReadInboxMessageForId("messageId")
+            CleverTap.markReadInboxMessagesForIds(["id1", "id2"])
             CleverTap.pushInboxNotificationViewedEventForId("messageId")
             CleverTap.pushInboxNotificationClickedEventForId("messageId")
+            CleverTap.dismissInbox()
         }
     )
     document.addEventListener('onCleverTapInboxMessagesDidUpdate', () => {
@@ -299,7 +365,7 @@ function initListeners() {
     )
     document.addEventListener('onCleverTapInboxItemClick', e => {
             log("onCleverTapInboxItemClick")
-            log(e.customExtras)
+            log(JSON.stringify(e))
         }
     )
     
@@ -331,6 +397,15 @@ function initListeners() {
             log(e.customExtras)
         }
     )
+    document.addEventListener('onCleverTapPushPermissionResponseReceived', e => {
+        log("onCleverTapPushPermissionResponseReceived")
+        log(e.accepted)
+    })
+
+    document.addEventListener('onCleverTapInAppNotificationShow', e => {
+        log("onCleverTapInAppNotificationShow")
+        log(e.customExtras)
+    })
 }
 
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -23,8 +23,7 @@ All calls to the CleverTap SDK should be made from your Javascript.
 
 ```javascript
 document.addEventListener('onCleverTapPushPermissionResponse', this.onCleverTapPushPermissionResponse,false);
-document.addEventListener('onCleverTapInAppNotificationShow', this.onCleverTapInAppNotificationShow,false);
-
+document.addEventListener('onCleverTapInAppNotificationShow', this.onCleverTapInAppNotificationShow,false);// Only for Android, NO-OP for iOS
 document.addEventListener('deviceready', this.onDeviceReady, false);
 document.addEventListener('onCleverTapProfileSync', this.onCleverTapProfileSync, false); // optional: to be notified of CleverTap user profile synchronization updates
 document.addEventListener('onCleverTapProfileDidInitialize', this.onCleverTapProfileDidInitialize, false); // optional, to be notified when the CleverTap user profile is initialized
@@ -48,7 +47,7 @@ onCleverTapPushPermissionResponse: function(e) {
    console.log(e.accepted)
 },
 
-// on inapp displayed
+// on inapp displayed, Only for Android, NO-OP for iOS
 onCleverTapInAppNotificationShow: function(e) {
    log("onCleverTapInAppNotificationShow")
    log(e.customExtras)

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -22,6 +22,9 @@ All calls to the CleverTap SDK should be made from your Javascript.
 
 
 ```javascript
+document.addEventListener('onCleverTapPushPermissionResponse', this.onCleverTapPushPermissionResponse,false);
+document.addEventListener('onCleverTapInAppNotificationShow', this.onCleverTapInAppNotificationShow,false);
+
 document.addEventListener('deviceready', this.onDeviceReady, false);
 document.addEventListener('onCleverTapProfileSync', this.onCleverTapProfileSync, false); // optional: to be notified of CleverTap user profile synchronization updates
 document.addEventListener('onCleverTapProfileDidInitialize', this.onCleverTapProfileDidInitialize, false); // optional, to be notified when the CleverTap user profile is initialized
@@ -40,6 +43,16 @@ document.addEventListener('onCleverTapProductConfigDidActivate', this.onCleverTa
 document.addEventListener('onCleverTapExperimentsUpdated', this.onCleverTapExperimentsUpdated, false); // optional, to check if Dynamic Variable Experiments were updated
 document.addEventListener('onCleverTapDisplayUnitsLoaded', this.onCleverTapDisplayUnitsLoaded, false); // optional, to check if Native Display units were loaded
 
+// Push Permission
+onCleverTapPushPermissionResponse: function(e) {
+   console.log(e.accepted)
+},
+
+// on inapp displayed
+onCleverTapInAppNotificationShow: function(e) {
+   log("onCleverTapInAppNotificationShow")
+   log(e.customExtras)
+},
 
 // deep link handling  
 onDeepLink: function(e) {
@@ -237,7 +250,7 @@ console.log('getInboxMessageForId: ' + r);
 this.clevertap.deleteInboxMessageForId('message_ID_1234');		
 ```
 
-#### Delete bulk messages with Ids - Only for iOS, NO-OP for Android.
+#### Delete bulk messages with Ids - Only for iOS, NO-OP for Android [*v2.7.0* onwards Android adds support for this method].
 
 ```javascript 
 this.clevertap.deleteInboxMessagesForIds(['message_ID_1234','message_ID_xyz']);        
@@ -247,6 +260,18 @@ this.clevertap.deleteInboxMessagesForIds(['message_ID_1234','message_ID_xyz']);
 
 ```javascript 
 this.clevertap.markReadInboxMessageForId('message_ID_1234');		
+```
+
+#### Mark bulk Inbox messages with Ids as Read
+
+```javascript 
+this.clevertap.markReadInboxMessagesForIds(['message_ID_1234','message_ID_xyz']);        
+```
+
+#### Dismiss the App Inbox
+
+```javascript 
+this.clevertap.dismissInbox();        
 ```
 
 #### pushInbox Notification Viewed Event For Id

--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -1,0 +1,119 @@
+# Overview
+You can define variables using the CleverTap Corova SDK. When you define a variable in your code, you can sync them to the CleverTap Dashboard via the provided SDK methods.
+
+# Supported Variable Types
+
+Currently, CleverTap SDK supports the following variable types:
+
+- String
+- boolean
+- JSON Object
+- number
+
+# Define Variables
+
+Variables can be defined using the `defineVariables` method. You must provide the names and default values of the variables using a JSON Object. 
+
+```javascript
+let variables = {
+              'cordova_var_string': 'cordova_var_string_value',
+              'cordova_var_map': {
+                'cordova_var_map_string': 'cordova_var_map_value'
+              },
+              'cordova_var_int': 6,
+              'cordova_var_float': 6.9,
+              'cordova_var_boolean': true
+            };
+this.clevertap.defineVariables(variables);
+```
+
+# Setup Callbacks
+
+CleverTap cordova SDK provides several callbacks for the developer to receive feedback from the SDK. You can use them as per your requirement, using all of them is not mandatory. They are as follows:
+
+## Status of Variables Fetch Request
+
+This method provides a boolean flag to ensure that the variables are successfully fetched from the server.
+
+```javascript
+this.clevertap.fetchVariables(success => log("fetchVariables success = " + success))
+```
+
+## `onVariablesChanged`
+
+This callback is invoked when variables are initialized with values fetched from the server. It is called each time new values are fetched.
+
+```javascript
+this.clevertap.onVariablesChanged(val => log("onVariablesChanged value is "+JSON.stringify(val)));
+```
+
+## `onValueChanged`
+
+This callback is invoked when the value of the variable changes. You must provide the name of the variable whose value needs to be observed.
+
+```javascript
+ this.clevertap.onValueChanged(key,val => log("Changed value is "+JSON.stringify(val)));
+```
+
+# Sync Defined Variables
+
+After defining your variables in the code, you must send/sync variables to the server. To do so, the app must be in DEBUG mode and mark a particular CleverTap user profile as a test profile from the CleverTap dashboard. [Learn how to mark a profile as **Test Profile**](https://developer.clevertap.com/docs/concepts-user-profiles#mark-a-user-profile-as-a-test-profile)
+
+After marking the profile as a test profile, you must sync the app variables in DEBUG mode:
+
+```javascript
+
+// 1. Define CleverTap variables 
+// …
+// 2. Add variables/values changed callbacks
+// …
+
+// 3. Sync CleverTap Variables from DEBUG mode/builds
+this.clevertap.syncVariables();
+```
+
+> 📘 Key Points to Remember
+> 
+> - In a scenario where there is already a draft created by another user profile in the dashboard, the sync call will fail to avoid overriding important changes made by someone else. In this case, Publish or Dismiss the existing draft before you proceed with syncing variables again. However, you can override a draft you created via the sync method previously to optimize the integration experience.
+> - You can receive the following console logs from the CleverTap SDK:
+>   - Variables synced successfully.
+>   - Unauthorized access from a non-test profile. Please mark this profile as a test profile from the CleverTap dashboard.
+
+# Fetch Variables During a Session
+
+You can fetch the updated values for your CleverTap variables from the server during a session. If variables have changed, the appropriate callbacks will be fired. The provided callback provides a boolean flag that indicates if the fetch call was successful. The callback is fired regardless of whether the variables have changed or not.
+
+```javascript
+this.clevertap.fetchVariables(success => log("fetchVariables success = " + success))
+```
+
+# Use Fetched Variables Values
+
+This process involves the following two major steps:
+
+1. Fetch variable values.
+2. Access variable values.
+
+## Fetch Variable Values
+
+Variables are updated automatically when server values are received. If you want to receive feedback when a specific variable is updated, use the individual callback:
+
+```javascript
+ this.clevertap.onValueChanged(key,val => log("Changed value is "+JSON.stringify(val)));
+```
+
+## Access Variable Values
+
+You can access these fetched values in the following two ways:
+
+### Getting all variables
+
+```javascript
+this.clevertap.getVariables(val => log("getVariables value is "+JSON.stringify(val)))
+```
+
+### Getting a specific variable
+
+```javascript
+this.clevertap.getVariable('cordova_var_string', val => log("cordova_var_string value is "+JSON.stringify(val));
+```

--- a/docs/pushprimer.md
+++ b/docs/pushprimer.md
@@ -1,0 +1,88 @@
+##  🔖 Overview
+
+Push Primer allows you to enable runtime push permission for sending notifications from an app.
+
+Starting with the v4.7.0 release, CleverTap Cordova supports Push primer for push notification runtime permission through local in-app.
+
+For Push Primer, minimum supported version for iOS platform is 10.0 while android 13 for the android platform.
+
+### Push Primer using Half-Interstitial local In-app
+```javascript
+let localInApp = {
+              inAppType: 'half-interstitial',
+              titleText: 'Get Notified',
+              messageText:
+                'Please enable notifications on your device to use Push Notifications.',
+              followDeviceOrientation: true,
+              positiveBtnText: 'Allow',
+              negativeBtnText: 'Cancel',
+              backgroundColor: '#FFFFFF',
+              btnBorderColor: '#0000FF',
+              titleTextColor: '#0000FF',
+              messageTextColor: '#000000',
+              btnTextColor: '#FFFFFF',
+              btnBackgroundColor: '#0000FF',
+              btnBorderRadius: '2',
+              fallbackToSettings: true,
+            };
+
+this.clevertap.promptPushPrimer(localInApp);
+```
+
+### Push Primer using Alert local In-app
+```javascript
+this.clevertap.promptPushPrimer({
+              inAppType: 'alert',
+              titleText: 'Get Notified',
+              messageText: 'Enable Notification permission',
+              followDeviceOrientation: true,
+              positiveBtnText: 'Allow',
+              negativeBtnText: 'Cancel',
+              fallbackToSettings: true,
+            });
+```
+
+### Prompt the Notification Permission Dialog (without push primer)
+It takes boolean as a parameter. If the value passed is true and permission is denied then we fallback to app’s notification settings. If false then we just give the callback saying permission is denied.
+
+```javascript
+this.clevertap.promptForPushPermission(true);    
+```
+
+### Get the Push notification permission status
+Returns the status of the push permission in the callback handler.
+
+```javascript
+this.clevertap.isPushPermissionGranted(val => log("isPushPermissionGranted by user " + val));
+```
+
+###  Description of the localInApp Object passed inside the PromptPushPrimer(localInApp) method
+
+Key Name| Parameters | Description | Required
+:---:|:---:|:---:|:---
+`inAppType` | "half-interstitial" or "alert" | Accepts only half-interstitial & alert type to display the local in-app | Required
+`titleText` | String | Sets the title of the local in-app | Required
+`messageText` | String | Sets the subtitle of the local in-app | Required
+`followDeviceOrientation` | true or false | If true then the local InApp is shown for both portrait and landscape. If it sets false then local InApp only displays for portrait mode | Required
+`positiveBtnText` | String | Sets the text of the positive button | Required
+`negativeBtnText` | String | Sets the text of the negative button | Required
+`fallbackToSettings` | true or false | If true and the permission is denied then we fallback to app’s notification settings, if it’s false then we just give the callback saying permission is denied. | Optional
+`backgroundColor` | Accepts Hex color as String | Sets the background color of the local in-app | Optional
+`btnBorderColor` | Accepts Hex color as String | Sets the border color of both positive/negative buttons | Optional
+`titleTextColor` | Accepts Hex color as String | Sets the title color of the local in-app | Optional
+`messageTextColor` | Accepts Hex color as String | Sets the sub-title color of the local in-app | Optional
+`btnTextColor` | Accepts Hex color as String | Sets the color of text for both positive/negative buttons | Optional
+`btnBackgroundColor` | Accepts Hex color as String | Sets the background color for both positive/negative buttons | Optional
+`btnBorderRadius` | String | Sets the radius for both positive/negative buttons. Default radius is “2” if not set | Optional
+`fallbackToSettings` | true or false | If the value passed is true then we fallback to app’s notification settings in case permission is denied. If false then we just give the callback saying permission is denied. | Optional
+
+
+###  Available Callbacks for Push Primer
+Based on notification permission grant/deny, CleverTap Cordova SDK provides a callback with the permission status.
+For this You can register the onCleverTapPushPermissionResponseReceived callback:
+```javascript
+document.addEventListener('onCleverTapPushPermissionResponseReceived', e => {
+        log("onCleverTapPushPermissionResponseReceived")
+        log(e.accepted) // grant or deny flag
+    })
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-cordova",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "CleverTap Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "clevertap-cordova",
@@ -20,8 +20,8 @@
     "cordova-android"
   ],
   "engines": {
-  "cordovaDependencies": {
-      "2.3.2": { 
+    "cordovaDependencies": {
+      "2.3.2": {
         "cordova-ios": ">=4.3.0",
         "cordova-android": ">6.3.0",
         "cordova": ">=7.0.0"
@@ -30,6 +30,10 @@
         "cordova-ios": ">=4.3.0",
         "cordova-android": ">=11.0.0",
         "cordova": ">=11.0.0"
+      },
+      "2.7.0": {
+        "cordova-android": ">=12.0.0",
+        "cordova": ">=12.0.0"
       }
     }
   },

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,7 @@
     </platform>
 
     <platform name="android">
-        <preference name="FIREBASE_MESSAGING_VERSION" default="22.0.0"/>
+        <preference name="FIREBASE_MESSAGING_VERSION" default="23.0.6"/>
 
         <config-file target="config.xml" parent="/*">
             <feature name="CleverTapPlugin" >
@@ -95,10 +95,10 @@
         <source-file src="src/android/CleverTapPlugin.java" target-dir="src/com/clevertap/cordova/" />
 
         <framework src="com.google.firebase:firebase-messaging:$FIREBASE_MESSAGING_VERSION" />
-        <framework src="com.clevertap.android:clevertap-android-sdk:4.6.6"/>
+        <framework src="com.clevertap.android:clevertap-android-sdk:5.1.0"/>
         <framework src="com.github.bumptech.glide:glide:4.12.0"/>
-        <framework src="androidx.appcompat:appcompat:1.3.1"/>
-        <framework src="androidx.core:core:1.3.0" />
+        <framework src="androidx.appcompat:appcompat:1.6.0-rc01"/>
+        <framework src="androidx.core:core:1.9.0" />
         <framework src="androidx.fragment:fragment:1.3.6"/>
         <framework src="androidx.recyclerview:recyclerview:1.2.1"/>
         <framework src="androidx.viewpager:viewpager:1.0.0" />

--- a/src/android/CleverTapPlugin.java
+++ b/src/android/CleverTapPlugin.java
@@ -2077,7 +2077,7 @@ public class CleverTapPlugin extends CordovaPlugin implements SyncListener, InAp
         final String json = "{'accepted':" + accepted + "}";
         webView.getView().post(new Runnable() {
             public void run() {
-                webView.loadUrl("javascript:cordova.fireDocumentEvent('onCleverTapPushPermissionResponse'," + json + ");");
+                webView.loadUrl("javascript:cordova.fireDocumentEvent('onCleverTapPushPermissionResponseReceived'," + json + ");");
             }
         });
     }

--- a/www/CleverTap.js
+++ b/www/CleverTap.js
@@ -567,6 +567,22 @@ CleverTap.prototype.reset = function(){
     cordova.exec(null, null, "CleverTapPlugin", "reset", []);
 }
 
+/****************************
+ * Android 13 Push Primer
+ ****************************/
+ 
+CleverTap.prototype.promptPushPrimer = function(localInAppObject){
+    cordova.exec(null, null, "CleverTapPlugin", "promptPushPrimer", [localInAppObject]);
+}
+
+CleverTap.prototype.promptForPushPermission = function(showFallbackSettings){
+    cordova.exec(null, null, "CleverTapPlugin", "promptForPushPermission", [showFallbackSettings]);
+}
+
+CleverTap.prototype.isPushPermissionGranted = function(successCallback){
+    cordova.exec(successCallback, null, "CleverTapPlugin", "isPushPermissionGranted", []);
+}
+
 function convertDateToEpochInProperties(items){
 //Conversion of date object in suitable CleverTap format
 


### PR DESCRIPTION
#### New Features

* Supports [CleverTap Android SDK v5.1.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev5.1.0_ptv1.1.0).
* Supports [cordova android 12.0.0](https://cordova.apache.org/announcements/2023/05/22/cordova-android-12.0.0.html)
* Adds below new public APIs for supporting [Android 13 notification runtime permission](https://developer.android.com/develop/ui/views/notifications/notification-permission)
  * `isPushPermissionGranted(successCallback)` [Usage can be found here](docs/pushprimer.md#get-the-push-notification-permission-status)
  * `promptPushPrimer(JSONObject)` [Usage can be found here](docs/pushprimer.md#push-primer-using-half-interstitial-local-in-app)
  * `promptForPushPermission(boolean)` [Usage can be found here](docs/pushprimer.md#prompt-the-notification-permission-dialog-without-push-primer)
  * New callback `onCleverTapPushPermissionResponseReceived` available which returns after user Allows/Denies notification permission [Usage can be found here](docs/pushprimer.md#available-callbacks-for-push-primer)
  * New callback `onCleverTapInAppNotificationShow(JSONObject)`
* Adds support for Remote Config Variables. Please refer to the [Variables.md](docs/Variables.md) file to
  read more on how to integrate this to your app.
* Adds new API, `markReadInboxMessagesForIds(messageIDs)` to mark read an array of
  Inbox Messages.
* `deleteInboxMessagesForIds(messageIDs)` is now supported in Android as well.
* Adds new API, `dismissInbox()` to dismiss the App Inbox.

#### API Changes

* **Deprecated:** The following methods and callbacks related to Product Config and Feature Flags have
  been marked as deprecated in this release, instead use new remote config variables feature. These
  methods and callbacks will be removed in the future versions with prior notice.
    * Product config
        - `setDefaultsMap()`
        - `fetch()`
        - `fetchWithMinimumFetchIntervalInSeconds()`
        - `activate()`
        - `fetchAndActivate()`
        - `setMinimumFetchIntervalInSeconds()`
        - `getLastFetchTimeStampInMillis()`
        - `getString()`
        - `getBoolean()`
        - `getLong()`
        - `getDouble()`
        - `reset()`
        - callback `onCleverTapProductConfigDidInitialize`
        - callback `onCleverTapProductConfigDidFetch`
        - callback `onCleverTapProductConfigDidActivate`
 
    * Feature flags
        - `getFeatureFlag()`
        - callback `onCleverTapFeatureFlagsDidUpdate`

#### Breaking API Changes

* **Return value change of `onCleverTapInboxItemClick` callback**: callback returns `JSONObject` with below entries
    - `data` corresponds to the payload of clicked inbox item
    - The `contentPageIndex` corresponds to the page index of the content, which ranges from 0 to the total number of pages for carousel templates. For non-carousel templates, the value is always 0, as they only have one page of content.
    - The `buttonIndex` represents the index of the App Inbox button clicked (0, 1, or 2). A value of -1 indicates the App Inbox item is clicked.
* **Behavioral change of `onCleverTapInboxItemClick` callback**:
  - Previously, the callback was raised when the App Inbox Item is clicked.
  - Now, it is also raised when the App Inbox button and Item is clicked.