### PR TITLE
Support core v5.2.0 SDK-3183

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Change Log
 ==========
+Version 2.7.1 *(August 16, 2023)*
+-------------------------------------------
+#### New Features
+
+**Android specific**
+* Supports [CleverTap Android SDK v5.2.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev5.2.0_hmsv1.3.3_xpsv1.5.3). This supported version includes encryption feature for PII data. Check encryption usage for cordova android [here](docs/Integrate-Android.md#setup-encryption-for-pii-data).
+
 Version 2.7.0 *(August 2, 2023)*
 -------------------------------------------
 #### New Features
@@ -62,6 +69,9 @@ Version 2.7.0 *(August 2, 2023)*
     - `data` corresponds to the payload of clicked inbox item
     - The `contentPageIndex` corresponds to the page index of the content, which ranges from 0 to the total number of pages for carousel templates. For non-carousel templates, the value is always 0, as they only have one page of content.
     - The `buttonIndex` represents the index of the App Inbox button clicked (0, 1, or 2). A value of -1 indicates the App Inbox item is clicked.
+
+#### Bug fixes
+* Fixes an XSS vulnerability - https://fluidattacks.com/advisories/maiden/ We recommend all users to update to v2.7.0 or above.
 
 Version 2.6.2 *(April 18, 2023)*
 -------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 Change Log
 ==========
-Version 2.7.1 *(August 16, 2023)*
+Version 2.7.1 *(August 17, 2023)*
 -------------------------------------------
 #### New Features
 
 **Android specific**
 * Supports [CleverTap Android SDK v5.2.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev5.2.0_hmsv1.3.3_xpsv1.5.3). This supported version includes encryption feature for PII data. Check encryption usage for cordova android [here](docs/Integrate-Android.md#setup-encryption-for-pii-data).
+
+**iOS specific**
+* Supports [CleverTap iOS SDK v5.2.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/5.2.0). This supported version includes encryption feature for PII data. Check encryption usage for cordova ios [here](docs/Integrate-iOS.md#setup-encryption-for-pii-data).
 
 Version 2.7.0 *(August 2, 2023)*
 -------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Version 2.7.1 *(August 17, 2023)*
 **iOS specific**
 * Supports [CleverTap iOS SDK v5.2.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/5.2.0). This supported version includes encryption feature for PII data. Check encryption usage for cordova ios [here](docs/Integrate-iOS.md#setup-encryption-for-pii-data).
 
+#### Bug Fixes
+* Fixes `NSInvalidArgumentException` for `getDisplayUnitForId` and `getInboxMessageForId` in iOS.
+
 Version 2.7.0 *(August 2, 2023)*
 -------------------------------------------
 #### New Features

--- a/docs/Integrate-Android.md
+++ b/docs/Integrate-Android.md
@@ -138,6 +138,22 @@ Use the following to delete a Notification Channel Group
 this.clevertap.deleteNotificationChannelGroup('groupID_5678');      
 ```
 
+## Setup encryption for PII data
+PII data is stored across the SDK and could be sensitive information. 
+From Cordova SDK `v2.7.1`. onwards, you can enable encryption for PII data wiz. **Email, Identity, Name and Phone**.  
+  
+Currently 2 levels of encryption are supported i.e None(0) and Medium(1). Encryption level is None by default.  
+
+**None** - All stored data is in plaintext    
+**Medium** - PII data is encrypted completely. 
+   
+Add encryption level in the `AndroidManifest.xml` as following,
+
+```xml
+<meta-data
+    android:name="CLEVERTAP_ENCRYPTION_LEVEL"
+    android:value="1" />
+```
 
 ## Integrate Javascript with the Plugin
 

--- a/docs/Integrate-iOS.md
+++ b/docs/Integrate-iOS.md
@@ -12,6 +12,17 @@
 CleverTap.registerPush();
 ```
 
+## Setup encryption for PII data
+PII data is stored across the SDK and could be sensitive information. 
+From Cordova SDK `v2.7.1`. onwards, you can enable encryption for PII data wiz. **Email, Identity, Name and Phone**.  
+  
+Currently 2 levels of encryption are supported i.e None(0) and Medium(1). Encryption level is None by default.  
+
+**None** - All stored data is in plaintext    
+**Medium** - PII data is encrypted completely. 
+   
+The only way to set encryption level is from the info.plist. Add the `CleverTapEncryptionLevel` String key to `info.plist` file where value 1 means Medium and 0 means None. Encryption Level will be None if any other value is provided.
+
 ## Integrate Javascript with the Plugin
 
 - Refer to our [Usage Documentation](/docs/Usage.md) for implementation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-cordova",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "CleverTap Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "clevertap-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.7.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="2.7.1">
     <name>CleverTap</name>
     <description>CleverTap Plugin for Cordova/PhoneGap</description>
     <license>Commercial</license>
@@ -104,7 +104,7 @@
         <source-file src="src/android/CleverTapPlugin.java" target-dir="src/com/clevertap/cordova/" />
 
         <framework src="com.google.firebase:firebase-messaging:$FIREBASE_MESSAGING_VERSION" />
-        <framework src="com.clevertap.android:clevertap-android-sdk:5.1.0"/>
+        <framework src="com.clevertap.android:clevertap-android-sdk:5.2.0"/>
         <framework src="com.github.bumptech.glide:glide:4.12.0"/>
         <framework src="androidx.appcompat:appcompat:1.6.0-rc01"/>
         <framework src="androidx.core:core:1.9.0" />

--- a/www/CleverTap.js
+++ b/www/CleverTap.js
@@ -7,7 +7,7 @@
 
 var CleverTap = function () {
     const libName = 'Cordova';
-    const libVersion = 20603; 
+    const libVersion = 20701; 
     cordova.exec(null, null, "CleverTapPlugin", "setLibrary", [libName, libVersion]);
 }
                


### PR DESCRIPTION
Supports [CleverTap Android SDK v5.2.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev5.2.0_hmsv1.3.3_xpsv1.5.3). This supported version includes encryption feature for PII data.