### PR TITLE
Release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 Change Log
 ==========
+Version 4.3.0 *(October 8 2025)*
+-------------------------------------------
+**What's new**
+* **[Android Platform]**
+    * Supports [CleverTap Android SDK v7.5.2](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-752-september-11-2025).
+
+* **[iOS Platform]**
+    * Supports [CleverTap iOS SDK v7.3.3](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-733-september-11-2025).
+
+**Bug Fixes**
+* **[Android and iOS Platform]**
+    * Fixes an issue where `profileGetProperty` didn't return `null` for non-existent keys
 
 Version 4.2.0 *(July 29 2025)*
 -------------------------------------------

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To get started, sign up [here](https://clevertap.com/live-product-demo/).
 
 ## ✅ Supported Versions
 
-- [CleverTap Android SDK version 7.5.0](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev7.5.0)
-- [CleverTap iOS SDK version 7.3.1](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/7.3.1)
+- [CleverTap Android SDK version 7.5.2](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev7.5.2)
+- [CleverTap iOS SDK version 7.3.3](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/7.3.3)
 
 ## 🚀 Installation and Quick Start
 

--- a/Samples/Cordova/ExampleProject/platforms/android/app/build.gradle
+++ b/Samples/Cordova/ExampleProject/platforms/android/app/build.gradle
@@ -326,7 +326,7 @@ dependencies {
     // SUB-PROJECT DEPENDENCIES START
     implementation(project(path: ":CordovaLib"))
     implementation "com.google.firebase:firebase-messaging:23.0.6"
-    implementation "com.clevertap.android:clevertap-android-sdk:7.5.0"
+    implementation "com.clevertap.android:clevertap-android-sdk:7.5.2"
     implementation "com.github.bumptech.glide:glide:4.12.0"
     implementation "androidx.appcompat:appcompat:1.6.0-rc01"
     implementation "androidx.core:core:1.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-cordova",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "CleverTap Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "clevertap-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="4.2.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="clevertap-cordova" version="4.3.0">
     <name>CleverTap</name>
     <description>CleverTap Plugin for Cordova/PhoneGap</description>
     <license>Commercial</license>
@@ -46,7 +46,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods>
-                <pod name="CleverTap-iOS-SDK" spec="7.3.1" />
+                <pod name="CleverTap-iOS-SDK" spec="7.3.3" />
             </pods>
         </podspec>
 <!--        <framework src="CleverTap-iOS-SDK" type="podspec" spec="5.1.2" />-->
@@ -113,7 +113,7 @@
         <source-file src="src/android/CleverTapEvent.java" target-dir="src/com/clevertap/cordova/" />
 
         <framework src="com.google.firebase:firebase-messaging:$FIREBASE_MESSAGING_VERSION" />
-        <framework src="com.clevertap.android:clevertap-android-sdk:7.5.0"/>
+        <framework src="com.clevertap.android:clevertap-android-sdk:7.5.2"/>
         <framework src="com.github.bumptech.glide:glide:4.12.0"/>
         <framework src="androidx.appcompat:appcompat:1.6.0-rc01"/>
         <framework src="androidx.core:core:1.9.0" />

--- a/src/android/CleverTapPlugin.java
+++ b/src/android/CleverTapPlugin.java
@@ -172,7 +172,7 @@ public class CleverTapPlugin extends CordovaPlugin implements SyncListener, InAp
 
                 if (!callbackDone) {
                     Map<String, Object> callbackResult = new HashMap<>();
-                    result.put("customExtras", data.toString());
+                    callbackResult.put("customExtras", data);
                     CleverTapEventEmitter.sendEvent(CleverTapEvent.ON_CLEVERTAP_PUSH_NOTIFICATION_TAPPED_WITH_CUSTOM_EXTRAS, callbackResult);
                 }
             }

--- a/src/android/CleverTapPlugin.java
+++ b/src/android/CleverTapPlugin.java
@@ -107,7 +107,7 @@ public class CleverTapPlugin extends CordovaPlugin implements SyncListener, InAp
         cleverTap.registerPushPermissionNotificationResponseListener(this);
 
         String libName = "Cordova";
-        int libVersion = 40200;
+        int libVersion = 40300;
         cleverTap.setLibrary(libName);
         cleverTap.setCustomSdkVersion(libName, libVersion);
 
@@ -1918,7 +1918,9 @@ public class CleverTapPlugin extends CordovaPlugin implements SyncListener, InAp
     @NonNull
     private PluginResult getPluginResult(final Status status, final Object value) {
         PluginResult result;
-        if (value instanceof Boolean) {
+        if (value == null) {
+            result = new PluginResult(status, (String) null);
+        } else if (value instanceof Boolean) {
             result  = new PluginResult(status, (Boolean) value);
         } else if (value instanceof Double) {
             result  = new PluginResult(status, ((Double) value).floatValue());

--- a/src/ios/CleverTapPlugin.m
+++ b/src/ios/CleverTapPlugin.m
@@ -809,7 +809,7 @@ static NSMutableDictionary *allVariables;
             id prop = [clevertap profileGet:propertyName];
             
             if(prop == nil) {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:NO];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:nil];
             }
             
             else if([prop isKindOfClass:[NSString class]]) {
@@ -1458,7 +1458,7 @@ static NSMutableDictionary *allVariables;
 
 - (void)setLibrary {
     NSString *libName = @"Cordova";
-    int libVersion = 40200;
+    int libVersion = 40300;
     [clevertap setLibrary:libName];
     [clevertap setCustomSdkVersion:libName version:libVersion];
 }


### PR DESCRIPTION
task(SDK-5243) - Release v4.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - profileGetProperty now returns null for non-existent keys on Android and iOS.
  - Improved null handling for plugin results on Android.

- Chores
  - Bumped plugin/package to 4.3.0.
  - Updated CleverTap SDKs to Android 7.5.2 and iOS 7.3.3.
  - Updated Android sample app dependency to match latest SDK.

- Documentation
  - Added 4.3.0 entry to the changelog and updated README supported versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->