### PR TITLE
feat(ios): support cold-start push notifications and deep links in UIScene-based apps

### DIFF
--- a/docs/Integrate-iOS.md
+++ b/docs/Integrate-iOS.md
@@ -6,6 +6,19 @@
 
 - If you plan on using deep links, [please register your custom url scheme as described here](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app).
 
+- **UIScene-based apps** (e.g. Capacitor 8.5+): on a cold start, iOS delivers the tapped notification / launch URL only to the scene delegate, so re-broadcast them from `scene(_:willConnectTo:options:)`:
+
+```swift
+if let response = connectionOptions.notificationResponse {
+    NotificationCenter.default.post(name: Notification.Name("CTSceneNotificationResponse"),
+                                    object: response.notification.request.content.userInfo)
+}
+if let urlContext = connectionOptions.urlContexts.first {
+    NotificationCenter.default.post(name: Notification.Name("CTSceneLaunchDeepLink"),
+                                    object: urlContext.url)
+}
+```
+
 - Call the following from your Javascript.
 
 ```javascript

--- a/src/ios/CleverTapPlugin.h
+++ b/src/ios/CleverTapPlugin.h
@@ -14,6 +14,8 @@ static NSString * const CTDidReceiveNotification = @"CTDidReceiveNotification";
 static NSString * const CTRemoteNotificationDidRegister = @"CTRemoteNotificationDidRegister";
 static NSString * const CTRemoteNotificationRegisterError = @"CTRemoteNotificationRegisterError";
 static NSString * const CTHandleOpenURLNotification = @"CTHandleOpenURLNotification";
+static NSString * const CTSceneNotificationResponse = @"CTSceneNotificationResponse";
+static NSString * const CTSceneLaunchDeepLink = @"CTSceneLaunchDeepLink";
 static NSString * const CTSendEvent = @"CTSendEvent";
 
 @interface CleverTapPlugin : CDVPlugin

--- a/src/ios/CleverTapPlugin.m
+++ b/src/ios/CleverTapPlugin.m
@@ -56,6 +56,12 @@ static NSMutableDictionary *allVariables;
     // Listen for UIApplicationDidFinishLaunchingNotification to get a hold of launchOptions
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onDidFinishLaunchingNotification:) name:UIApplicationDidFinishLaunchingNotification object:nil];
     
+    // Listen to re-broadcast scene connection options from the app's SceneDelegate.
+    // Under the UIScene lifecycle, launchOptions no longer carry the notification /
+    // URL that launched the app, and only the scene delegate receives them.
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onSceneNotificationResponse:) name:CTSceneNotificationResponse object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onSceneLaunchDeepLink:) name:CTSceneLaunchDeepLink object:nil];
+    
     // Listen to re-broadcast events from Cordova's AppDelegate
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onDidFailToRegisterForRemoteNotificationsWithError:) name:CTRemoteNotificationRegisterError object:nil];
     
@@ -78,6 +84,29 @@ static NSMutableDictionary *allVariables;
     if (launchOptions[UIApplicationLaunchOptionsURLKey]) {
         launchDeepLink = launchOptions[UIApplicationLaunchOptionsURLKey];
     }
+}
+
+// UIScene counterparts of onDidFinishLaunchingNotification: fill the same launch
+// buffers, delivered to Javascript through the existing notifyDeviceReady path.
+
++ (void)onSceneNotificationResponse:(NSNotification *)notification {
+    
+    if (![notification.object isKindOfClass:[NSDictionary class]]) return;
+    
+    if (!clevertap) clevertap = [CleverTap sharedInstance];
+    NSDictionary *userInfo = notification.object;
+    [clevertap handleNotificationWithData:userInfo];
+    launchNotification = userInfo;
+}
+
++ (void)onSceneLaunchDeepLink:(NSNotification *)notification {
+    
+    if (![notification.object isKindOfClass:[NSURL class]]) return;
+    
+    if (!clevertap) clevertap = [CleverTap sharedInstance];
+    NSURL *url = notification.object;
+    [clevertap handleOpenURL:url sourceApplication:nil];
+    launchDeepLink = url;
 }
 
 + (void)onDidFailToRegisterForRemoteNotificationsWithError:(NSNotification *)notification {


### PR DESCRIPTION
## Problem

Under the UIScene lifecycle (adopted by Capacitor 8.5+, required by newer Xcode versions), `UIApplicationDidFinishLaunchingNotification` no longer carries the remote notification or URL that launched the app — iOS delivers them only to the scene delegate via `UIScene.ConnectionOptions`. The plugin's `launchNotification` / `launchDeepLink` capture in `+load` therefore never fires, and **cold-start push tap-throughs and deep links are silently lost**. Warm starts keep working (the instance-level `CTDidReceiveNotification` / `CTHandleOpenURLNotification` observers exist by then).

## Fix

Two new class-level observers in `+load`, mirroring the existing `launchOptions` capture:

- `CTSceneNotificationResponse` → fills `launchNotification`
- `CTSceneLaunchDeepLink` → fills `launchDeepLink`

The host app's SceneDelegate re-broadcasts the scene connection options (snippet added to docs/Integrate-iOS.md); delivery to Javascript rides the existing `notifyDeviceReady` path unchanged.

## Notes

- **Purely additive** — apps on the classic `UIApplicationDelegate` lifecycle never post these notifications, so behavior there is untouched. The two capture paths are mutually exclusive: legacy apps have populated `launchOptions` and no scene events; scene apps have empty `launchOptions`.
- The plugin cannot handle this self-contained: UIKit's `UISceneWillConnectNotification` does not include the connection options — only the scene delegate method receives them. A re-broadcast from the host app is the minimal contract, consistent with the existing AppDelegate re-broadcasts (`CTDidReceiveNotification`, `CTHandleOpenURLNotification`, `CTRemoteNotificationDidRegister`).
- Reproduced on device in a Capacitor 8.5 app: warm push tap-through routes correctly, cold start loses the deep link. Fixed with this change plus the README SceneDelegate snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling push notification responses and deep-link URLs during iOS scene-based app launches.
  * Ensures launch data is captured and delivered when the app becomes ready.

* **Documentation**
  * Added guidance for configuring UIScene-based iOS integrations to forward cold-start notifications and deep links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->